### PR TITLE
Biowulf

### DIFF
--- a/workflow/profiles/biowulf/config.yaml
+++ b/workflow/profiles/biowulf/config.yaml
@@ -1,9 +1,12 @@
-restart-times: 3
+restart-times: 0
 jobscript: "slurm-jobscript.sh"
 cluster: "slurm-submit.py"
-cluster-status: "slurm-status.py"
+# don't murder the slurm controller please
+#cluster-status: "slurm-status.py"
 max-jobs-per-second: 1
-max-status-checks-per-second: 10
+# this setting is not always respected properly so
+# running without status checks is preferable
+max-status-checks-per-second: 0.01
 local-cores: 1
 latency-wait: 60
 rerun-incomplete: true

--- a/workflow/profiles/biowulf/config.yaml
+++ b/workflow/profiles/biowulf/config.yaml
@@ -7,6 +7,6 @@ max-jobs-per-second: 1
 # this setting is not always respected properly so
 # running without status checks is preferable
 max-status-checks-per-second: 0.01
-local-cores: 1
-latency-wait: 60
+local-cores: 2
+latency-wait: 180
 rerun-incomplete: true


### PR DESCRIPTION
gemscan runs have been saturating the slurm controller with queue status requests. `max-status-checks-per-second: 0.01` theoretically prevents that but snakemake apparently makes more requests than the theoretical limit. Therefore the best way is to stop querying the status via squeue/sacct and revert back to using the status files generated by the jobscript instead.

Finally - slurm allocation on biowulf is always at least 2 cores - might as well use them.
And a longer latency-wait is safer