### PR TITLE
changed the temp directory for bcftools sort

### DIFF
--- a/workflow/rules/Snakefile_DeepVariant
+++ b/workflow/rules/Snakefile_DeepVariant
@@ -56,8 +56,6 @@ rule DV_concat_vcfs:
         idx=expand("deepVariant/called/{chrom}/{{sample}}.vcf.gz.tbi", chrom=chromList),
     output:
         gz="deepVariant/called/vcfs/{sample}_all_chroms.vcf.gz",
-    params:
-        temp(directory("DV_concat_vcfs/{sample}/")),
     benchmark:
         "run_times/DV_concat_vcfs/{sample}.tsv"
     conda:
@@ -65,7 +63,7 @@ rule DV_concat_vcfs:
     singularity:
         "docker://ghcr.io/shukwong/bcftools:20240501"
     shell:
-        "mkdir -p {params}; bcftools concat -Ou -a {input.vcf} | bcftools sort -T {params} -Oz -o {output.gz}" # sort -k1,1 -k2,2n > {output}'
+        "mkdir -p {params}; bcftools concat -Ou -a {input.vcf} | bcftools sort -T ./deepVariant/ -Oz -o {output.gz}" # sort -k1,1 -k2,2n > {output}'
 
 
 rule DV_create_each_sample_manifest:

--- a/workflow/rules/Snakefile_HaplotypeCaller
+++ b/workflow/rules/Snakefile_HaplotypeCaller
@@ -215,8 +215,6 @@ rule HC_concat_vcfs:
         idx=expand("HaplotypeCaller/called/{chrom}/{{sample}}.vcf.gz.tbi", chrom=chromList),
     output:
         gz="HaplotypeCaller/called/vcfs/{sample}_all_chroms.vcf.gz",
-    params:
-        temp(directory("HC_concat_vcfs/{sample}/")),
     benchmark:
         "run_times/HC_concat_vcfs/{sample}.tsv"
     conda:
@@ -224,7 +222,7 @@ rule HC_concat_vcfs:
     singularity:
         "docker://ghcr.io/shukwong/bcftools:20240501"
     shell:
-        "mkdir -p {params}; bcftools concat -Ou -a {input.vcf} | bcftools sort -T {params} -Oz -o {output.gz}" # sort -k1,1 -k2,2n > {output}'
+        "mkdir -p {params}; bcftools concat -Ou -a {input.vcf} | bcftools sort -T ./HaplotypeCaller/ -Oz -o {output.gz}" # sort -k1,1 -k2,2n > {output}'
 
 
 

--- a/workflow/rules/Snakefile_Strelka2
+++ b/workflow/rules/Snakefile_Strelka2
@@ -123,8 +123,6 @@ rule strelka_concatVariantsByChrom:
         idx=expand("strelka2/genotyped/strelka2_variants_{chrom}.bcf.csi", chrom=chromList),
     output:
         temp("strelka2/genotyped/strelka2_variants.bcf"),
-    params:
-        temp(directory("strelka2_concat_vcfs/")),
     benchmark:
         "run_times/strelka_concatVariantsByChrom/concatVariantsByChrom.tsv"
     conda:
@@ -132,7 +130,7 @@ rule strelka_concatVariantsByChrom:
     singularity:
         'docker://ghcr.io/shukwong/bcftools:20240501'      
     shell:
-        "bcftools concat -Ou -a {input.vcf} | bcftools sort -T {params} -Oz -o {output}"
+        "bcftools concat -Ou -a {input.vcf} | bcftools sort -T ./strelka2/ -Oz -o {output}"
 
 
 rule strelka_indexBCFByChrom:


### PR DESCRIPTION
using the param option to crease temp(directory(<temp_directory>)) is causing problems. Currently the solution is to set the temp directory for bcftools sort to an output directory. This is a temporary fix and be looking for a better solution later. 